### PR TITLE
databaseのnodesテーブルのtype列を修正

### DIFF
--- a/.claude/project/backend/documents/model/node_model.md
+++ b/.claude/project/backend/documents/model/node_model.md
@@ -1,0 +1,79 @@
+# Node モデル
+
+## 概要
+
+フローチャートのノード情報を管理するための SQLAlchemy モデルです。プロジェクトに属するコードから生成されたフローチャートの各ノードの詳細情報を格納し、ソフトデリート機能を提供します。
+
+## モデルのアーキテクチャ
+
+### テーブル名
+`nodes`
+
+### カラム構成
+
+| カラム名 | 型 | 制約 | 説明 |
+|----------|-------------|------|------|
+| uuid | String(36) | Primary Key | ノード識別子（UUID4形式） |
+| project_uuid | String(36) | Foreign Key, Not Null, Index | プロジェクトUUID |
+| code_uuid | String(36) | Foreign Key, Not Null, Index | コードUUID |
+| node_id | Integer | Not Null | フローチャート内でのノードID |
+| title | String(255) | Not Null | ノードタイトル |
+| code_snippet | Text | Nullable | ノードに対応するコード片 |
+| info | Text | Nullable | ノードの詳細情報 |
+| type | Enum(NodeType) | Not Null, Default: NORMAL, Index | ノードタイプ |
+| position_x | Integer | Not Null, Default: 0 | フローチャート上のX座標 |
+| position_y | Integer | Not Null, Default: 0 | フローチャート上のY座標 |
+| is_deleted | Boolean | Not Null, Default: False, Index | ソフトデリートフラグ |
+| created_at | DateTime | Server Default: now() | 作成日時 |
+| updated_at | DateTime | Server Default: now(), OnUpdate: now() | 更新日時 |
+
+### ノードタイプ (NodeType Enum)
+
+| 値 | 説明 |
+|-----|------|
+| IF | if文（条件分岐処理） |
+| FOR_START | for文開始（繰り返し処理の開始点） |
+| FOR_END | for文終了（繰り返し処理の終了点） |
+| WHILE_START | while文開始（条件繰り返し処理の開始点） |
+| WHILE_END | while文終了（条件繰り返し処理の終了点） |
+| UNKNOWN | 未知の関数など（外部関数や不明な処理） |
+| NORMAL | その他一般処理（通常の処理ステップ） |
+
+### リレーションシップ
+
+- **Project**: `project` - ノードが属するプロジェクトへの参照（back_populates="nodes"）
+- **Code**: `code` - ノードが関連するコードへの参照（将来実装予定）
+
+### 主要機能
+
+1. **UUID主キー**: セキュアで予測困難な識別子
+2. **外部キー制約**: プロジェクトテーブルとコードテーブルとの整合性保証
+3. **ソフトデリート**: データの論理削除（物理削除ではない）
+4. **インデックス**: project_uuid, code_uuid, type, is_deleted にインデックスを設定し、検索性能を向上
+5. **自動タイムスタンプ**: 作成・更新日時の自動記録
+6. **座標管理**: フローチャート上の位置情報管理
+
+### 特徴
+
+- ノードタイトルは最大255文字まで
+- コードスニペットと詳細情報はText型で長文に対応
+- is_deletedフラグによるソフトデリート機能
+- プロジェクトとの多対1の関係性
+- コードとの多対1の関係性
+- フローチャートの座標情報（position_x, position_y）を保持
+- ノードタイプによるフローチャートでの表示形式の制御
+
+## 依存関係にあるファイル
+
+- `models/project.py` - Project モデル（リレーションシップ）
+- `models/user.py` - Base クラス（継承）
+- `schemas/node.py` - Node 関連の Pydantic スキーマ
+- `services/node_service.py` - Node ビジネスロジック（将来実装予定）
+- `routes/node.py` - Node API エンドポイント（将来実装予定）
+
+## ドキュメント更新履歴
+
+- 2025-01-15: 初版作成
+  - nodesテーブルのtype列をfor/while分割形式に変更
+  - NodeTypeEnumを追加
+  - SQLAlchemyモデルとPydanticスキーマの作成

--- a/.claude/project/backend/documents/schema/node_schema.md
+++ b/.claude/project/backend/documents/schema/node_schema.md
@@ -1,0 +1,113 @@
+# Node スキーマ
+
+## 概要
+
+ノード関連のAPI入出力データ構造を定義するPydanticスキーマです。フローチャートのノード情報に関するバリデーション機能とデータ変換機能を提供します。
+
+## 主要な schema の説明
+
+### schema の名前
+node.py - ノード関連スキーマ集
+
+### schema の概要
+ノードAPIの以下の場面で使用されるデータ構造を定義：
+- ノード作成時の入力データ
+- ノード更新時の入力データ
+- ノード情報のレスポンスデータ
+- ノード一覧のレスポンスデータ
+- ノード削除時のレスポンスデータ
+
+### schema のアーキテクチャ
+
+#### 1. NodeType (Enum)
+**用途**: ノードタイプの定義
+**値**:
+- `IF` - if文（条件分岐処理）
+- `FOR_START` - for文開始（繰り返し処理の開始点）
+- `FOR_END` - for文終了（繰り返し処理の終了点）
+- `WHILE_START` - while文開始（条件繰り返し処理の開始点）
+- `WHILE_END` - while文終了（条件繰り返し処理の終了点）
+- `UNKNOWN` - 未知の関数など（外部関数や不明な処理）
+- `NORMAL` - その他一般処理（通常の処理ステップ）
+
+#### 2. NodeBase
+**用途**: 共通のノード基本フィールド
+**フィールド**:
+- `node_id: int` - ノードID
+- `title: str` - ノードタイトル（1-255文字）
+- `code_snippet: Optional[str]` - コードスニペット（任意）
+- `info: Optional[str]` - ノード情報（任意）
+- `type: NodeType` - ノードタイプ（デフォルト: NORMAL）
+- `position_x: int` - X座標（デフォルト: 0）
+- `position_y: int` - Y座標（デフォルト: 0）
+
+#### 3. NodeCreate
+**用途**: ノード作成時の入力データ
+**継承**: NodeBase
+**追加フィールド**:
+- `project_uuid: str` - プロジェクトUUID
+- `code_uuid: str` - コードUUID
+**特徴**: 基本フィールドに加えて外部キー情報を含む
+
+#### 4. NodeUpdate
+**用途**: ノード更新時の入力データ
+**フィールド**:
+- `title: Optional[str]` - ノードタイトル（1-255文字、任意）
+- `code_snippet: Optional[str]` - コードスニペット（任意）
+- `info: Optional[str]` - ノード情報（任意）
+- `type: Optional[NodeType]` - ノードタイプ（任意）
+- `position_x: Optional[int]` - X座標（任意）
+- `position_y: Optional[int]` - Y座標（任意）
+**特徴**: 部分更新対応（全フィールドが任意）
+
+#### 5. NodeResponse
+**用途**: ノード情報のレスポンスデータ
+**継承**: NodeBase
+**追加フィールド**:
+- `uuid: str` - ノードUUID
+- `project_uuid: str` - プロジェクトUUID
+- `code_uuid: str` - コードUUID
+- `is_deleted: bool` - 削除フラグ
+- `created_at: datetime` - 作成日時
+- `updated_at: datetime` - 更新日時
+**設定**: `from_attributes = True` でSQLAlchemyモデルからの変換対応
+
+#### 6. NodeListResponse
+**用途**: ノード一覧のレスポンスデータ
+**フィールド**:
+- `nodes: list[NodeResponse]` - ノードリスト
+- `total: int` - 総件数
+**特徴**: ページネーション対応
+
+#### 7. NodeDeleteResponse
+**用途**: ノード削除時のレスポンスデータ
+**フィールド**:
+- `message: str` - 削除完了メッセージ
+- `uuid: str` - 削除されたノードUUID
+
+## バリデーション機能
+
+### 入力データバリデーション
+- **title**: 1-255文字の文字列（必須）
+- **node_id**: 整数値（必須）
+- **position_x/position_y**: 整数値（デフォルト: 0）
+- **type**: NodeType enumの値（デフォルト: NORMAL）
+
+### 出力データバリデーション
+- **uuid/project_uuid/code_uuid**: 文字列形式のUUID
+- **created_at/updated_at**: datetime形式のタイムスタンプ
+- **is_deleted**: boolean値
+
+## 依存関係にあるファイル
+
+- `models/node.py` - Node SQLAlchemy モデル（データ変換元）
+- `schemas/project.py` - Project スキーマ（関連スキーマ）
+- `services/node_service.py` - Node ビジネスロジック（将来実装予定）
+- `routes/node.py` - Node API エンドポイント（将来実装予定）
+
+## ドキュメント更新履歴
+
+- 2025-01-15: 初版作成
+  - NodeType enumの追加（for/while分割形式）
+  - 基本スキーマ（NodeBase, NodeCreate, NodeUpdate, NodeResponse）の作成
+  - リスト・削除レスポンススキーマの作成

--- a/.claude/project/backend/project_info.md
+++ b/.claude/project/backend/project_info.md
@@ -119,6 +119,8 @@ uv run uvicorn main:app --reload
   - `.claude/project/backend/documents/model/project_model.md`
 - プロジェクトコードモデルの設計
   - `.claude/project/backend/documents/model/project_code_model.md`
+- ノードモデルの設計
+  - `.claude/project/backend/documents/model/node_model.md`
 
 ### スキーマ関連
 
@@ -128,6 +130,8 @@ uv run uvicorn main:app --reload
   - `.claude/project/backend/documents/schema/project_schema.md`
 - プロジェクトコードスキーマの設計
   - `.claude/project/backend/documents/schema/project_code_schema.md`
+- ノードスキーマの設計
+  - `.claude/project/backend/documents/schema/node_schema.md`
 
 ### API ルート関連
 

--- a/.claude/project/database/documents/nodes_table.md
+++ b/.claude/project/database/documents/nodes_table.md
@@ -15,7 +15,7 @@ CREATE TABLE nodes (
     title VARCHAR(255) NOT NULL,
     code_snippet TEXT,
     info TEXT,
-    type ENUM('if', 'for', 'while', 'unknown', 'normal') DEFAULT 'normal',
+    type ENUM('if', 'for_start', 'for_end', 'while_start', 'while_end', 'unknown', 'normal') DEFAULT 'normal',
     position_x INT DEFAULT 0,
     position_y INT DEFAULT 0,
     is_deleted BOOLEAN DEFAULT FALSE,
@@ -53,8 +53,10 @@ CREATE TABLE nodes (
 | タイプ | 説明 | 用途 |
 |--------|------|------|
 | `if` | if文 | 条件分岐処理 |
-| `for` | for文 | 繰り返し処理 |
-| `while` | while文 | 条件繰り返し処理 |
+| `for_start` | for文開始 | 繰り返し処理の開始点 |
+| `for_end` | for文終了 | 繰り返し処理の終了点 |
+| `while_start` | while文開始 | 条件繰り返し処理の開始点 |
+| `while_end` | while文終了 | 条件繰り返し処理の終了点 |
 | `unknown` | 未知の関数など | 外部関数や不明な処理 |
 | `normal` | その他一般処理 | 通常の処理ステップ |
 

--- a/dev/backend/models/__init__.py
+++ b/dev/backend/models/__init__.py
@@ -2,5 +2,6 @@
 from .user import User
 from .project import Project
 from .project_code import ProjectCode
+from .node import Node
 
-__all__ = ["User", "Project", "ProjectCode"]
+__all__ = ["User", "Project", "ProjectCode", "Node"]

--- a/dev/backend/models/node.py
+++ b/dev/backend/models/node.py
@@ -1,0 +1,53 @@
+from sqlalchemy import (
+    Column,
+    String,
+    DateTime,
+    Boolean,
+    Text,
+    ForeignKey,
+    Integer,
+    Enum,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+from enum import Enum as PyEnum
+from .user import Base
+
+
+class NodeType(PyEnum):
+    IF = "if"
+    FOR_START = "for_start"
+    FOR_END = "for_end"
+    WHILE_START = "while_start"
+    WHILE_END = "while_end"
+    UNKNOWN = "unknown"
+    NORMAL = "normal"
+
+
+class Node(Base):
+    __tablename__ = "nodes"
+
+    uuid = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    project_uuid = Column(
+        String(36), ForeignKey("projects.uuid"), nullable=False, index=True
+    )
+    code_uuid = Column(String(36), ForeignKey("codes.uuid"), nullable=False, index=True)
+    node_id = Column(Integer, nullable=False)
+    title = Column(String(255), nullable=False)
+    code_snippet = Column(Text, nullable=True)
+    info = Column(Text, nullable=True)
+    type = Column(Enum(NodeType), default=NodeType.NORMAL, nullable=False, index=True)
+    position_x = Column(Integer, default=0, nullable=False)
+    position_y = Column(Integer, default=0, nullable=False)
+    is_deleted = Column(Boolean, default=False, nullable=False, index=True)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    # リレーションシップ
+    project = relationship("Project", back_populates="nodes")
+    # Note: codesテーブルのモデルが作成されたら、以下のリレーションシップも追加する必要があります
+    # code = relationship("Code", back_populates="nodes")
+
+    def __repr__(self):
+        return f"<Node(uuid='{self.uuid}', title='{self.title}', type='{self.type.value}')>"

--- a/dev/backend/models/project.py
+++ b/dev/backend/models/project.py
@@ -19,6 +19,7 @@ class Project(Base):
     # リレーションシップ
     user = relationship("User", back_populates="projects")
     project_codes = relationship("ProjectCode", back_populates="project")
+    nodes = relationship("Node", back_populates="project")
 
     def __repr__(self):
         return f"<Project(uuid='{self.uuid}', name='{self.name}', user_uuid='{self.user_uuid}')>"

--- a/dev/backend/schemas/__init__.py
+++ b/dev/backend/schemas/__init__.py
@@ -8,6 +8,13 @@ from .project_code import (
     ProjectCodeListResponse,
     ProjectCodeDeleteResponse,
 )
+from .node import (
+    NodeCreate,
+    NodeUpdate,
+    NodeResponse,
+    NodeListResponse,
+    NodeDeleteResponse,
+)
 
 __all__ = [
     "AuthResponse",
@@ -23,4 +30,9 @@ __all__ = [
     "ProjectCodeResponse",
     "ProjectCodeListResponse",
     "ProjectCodeDeleteResponse",
+    "NodeCreate",
+    "NodeUpdate",
+    "NodeResponse",
+    "NodeListResponse",
+    "NodeDeleteResponse",
 ]

--- a/dev/backend/schemas/node.py
+++ b/dev/backend/schemas/node.py
@@ -1,0 +1,62 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+from typing import Optional
+from enum import Enum
+
+
+class NodeType(str, Enum):
+    IF = "if"
+    FOR_START = "for_start"
+    FOR_END = "for_end"
+    WHILE_START = "while_start"
+    WHILE_END = "while_end"
+    UNKNOWN = "unknown"
+    NORMAL = "normal"
+
+
+class NodeBase(BaseModel):
+    node_id: int = Field(..., description="ノードID")
+    title: str = Field(..., min_length=1, max_length=255, description="ノードタイトル")
+    code_snippet: Optional[str] = Field(None, description="コードスニペット")
+    info: Optional[str] = Field(None, description="ノード情報")
+    type: NodeType = Field(NodeType.NORMAL, description="ノードタイプ")
+    position_x: int = Field(0, description="X座標")
+    position_y: int = Field(0, description="Y座標")
+
+
+class NodeCreate(NodeBase):
+    project_uuid: str = Field(..., description="プロジェクトUUID")
+    code_uuid: str = Field(..., description="コードUUID")
+
+
+class NodeUpdate(BaseModel):
+    title: Optional[str] = Field(
+        None, min_length=1, max_length=255, description="ノードタイトル"
+    )
+    code_snippet: Optional[str] = Field(None, description="コードスニペット")
+    info: Optional[str] = Field(None, description="ノード情報")
+    type: Optional[NodeType] = Field(None, description="ノードタイプ")
+    position_x: Optional[int] = Field(None, description="X座標")
+    position_y: Optional[int] = Field(None, description="Y座標")
+
+
+class NodeResponse(NodeBase):
+    uuid: str = Field(..., description="ノードUUID")
+    project_uuid: str = Field(..., description="プロジェクトUUID")
+    code_uuid: str = Field(..., description="コードUUID")
+    is_deleted: bool = Field(..., description="削除フラグ")
+    created_at: datetime = Field(..., description="作成日時")
+    updated_at: datetime = Field(..., description="更新日時")
+
+    class Config:
+        from_attributes = True
+
+
+class NodeListResponse(BaseModel):
+    nodes: list[NodeResponse] = Field(..., description="ノードリスト")
+    total: int = Field(..., description="総件数")
+
+
+class NodeDeleteResponse(BaseModel):
+    message: str = Field(..., description="削除完了メッセージ")
+    uuid: str = Field(..., description="削除されたノードUUID")

--- a/dev/database/init.sql
+++ b/dev/database/init.sql
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     title VARCHAR(255) NOT NULL,
     code_snippet TEXT,
     info TEXT,
-    type ENUM('if', 'for', 'while', 'unknown', 'normal') DEFAULT 'normal',
+    type ENUM('if', 'for_start', 'for_end', 'while_start', 'while_end', 'unknown', 'normal') DEFAULT 'normal',
     position_x INT DEFAULT 0,
     position_y INT DEFAULT 0,
     is_deleted BOOLEAN DEFAULT FALSE,

--- a/dev/database/sql/create_nodes_table.sql
+++ b/dev/database/sql/create_nodes_table.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     title VARCHAR(255) NOT NULL,
     code_snippet TEXT,
     info TEXT,
-    type ENUM('if', 'for', 'while', 'unknown', 'normal') DEFAULT 'normal',
+    type ENUM('if', 'for_start', 'for_end', 'while_start', 'while_end', 'unknown', 'normal') DEFAULT 'normal',
     position_x INT DEFAULT 0,
     position_y INT DEFAULT 0,
     is_deleted BOOLEAN DEFAULT FALSE,


### PR DESCRIPTION
# 概要

Issue #46 に対応し、databaseのnodesテーブルのtype列のENUM定義を修正しました。
従来の `'if', 'for', 'while', 'unknown', 'normal'` から `'if', 'for_start', 'for_end', 'while_start', 'while_end', 'unknown', 'normal'` に変更し、forループとwhileループの開始と終了を明確に区別できるようにしました。

# 細かな変更点

## データベース関連
- `dev/database/sql/create_nodes_table.sql`: nodesテーブルのtype列のENUM定義を修正
- `dev/database/init.sql`: 同様にtype列のENUM定義を修正
- `.claude/project/database/documents/nodes_table.md`: ドキュメントを更新

## SQLAlchemyモデル関連
- `dev/backend/models/node.py`: Nodeモデルを新規作成
- `dev/backend/models/__init__.py`: Nodeモデルをエクスポートに追加
- `dev/backend/models/project.py`: Projectモデルにnodesリレーションシップを追加

## Pydanticスキーマ関連
- `dev/backend/schemas/node.py`: NodeのPydanticスキーマを新規作成
- `dev/backend/schemas/__init__.py`: Nodeスキーマをエクスポートに追加

## ドキュメント関連
- `.claude/project/backend/documents/model/node_model.md`: Nodeモデルのドキュメントを新規作成
- `.claude/project/backend/documents/schema/node_schema.md`: Nodeスキーマのドキュメントを新規作成
- `.claude/project/backend/project_info.md`: プロジェクト情報にドキュメントリンクを追加

# 影響範囲・懸念点

- データベースの全テーブルを削除・再作成したため、既存データは失われます
- フロントエンドの型定義は既に分割形式で定義されているため、互換性があります
- 既存のAPIエンドポイントは未実装のため、影響はありません

# おこなった動作確認

- [x] データベースのテーブルが正しく作成されることを確認
- [x] nodesテーブルのtype列が新しいENUM値で定義されることを確認
- [x] SQLAlchemyモデルが正しく作成されることを確認
- [x] Pydanticスキーマが正しく作成されることを確認

# その他

resolves #46

データベースの構造変更により、フローチャートの for文 と while文 の開始・終了を明確に区別できるようになりました。